### PR TITLE
Fix authentication

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,5 +43,7 @@ apps:
     plugs:
     - home
     - network
+    - network-bind
+    - desktop
     - ssh-keys
     completer: completion.sh


### PR DESCRIPTION
Thanks for making this snap. You beat me to it by about 3 hours :D
When issuing a `gh pr list` the cli app needs to spark up a browser and listen for the authentication token. This PR adds the necessary interfaces (desktop and network-bind) to enable that. Tested locally on Ubuntu 20.04